### PR TITLE
Update dependencies

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,6 +11,7 @@ export default [
 		files: ["**/*.js", "**/*.ts"],
 		languageOptions: {
 			sourceType: "module",
+			ecmaVersion: 2022,
 			globals: {
 				...globals.node,
 				// es2022 is not available

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -17,7 +17,7 @@ export default [
 				// es2022 is not available
 				// https://github.com/sindresorhus/globals/issues/183
 				...globals.es2021,
-				"NodeJS": true,
+				NodeJS: true,
 			},
 		},
 		rules: {
@@ -70,9 +70,9 @@ export default [
 			},
 		},
 		rules: {
-			...typescriptPlugin.configs.recommended.rules,
-			...typescriptPlugin.configs["recommended-requiring-type-checking"].rules,
-			...typescriptPlugin.configs.strict.rules,
+			...typescriptPlugin.configs["recommended-type-checked"].rules,
+			...typescriptPlugin.configs["strict-type-checked"].rules,
+			...typescriptPlugin.configs["stylistic-type-checked"].rules,
 		},
 	},
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 			"devDependencies": {
 				"@typescript-eslint/eslint-plugin": "^5.59.11",
 				"@typescript-eslint/parser": "^5.59.11",
-				"eslint": "^8.43.0",
+				"eslint": "^8.49.0",
 				"typescript": "^5.2.2"
 			},
 			"engines": {
@@ -137,23 +137,23 @@
 			}
 		},
 		"node_modules/@eslint-community/regexpp": {
-			"version": "4.5.1",
-			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.1.tgz",
-			"integrity": "sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==",
+			"version": "4.8.0",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.8.0.tgz",
+			"integrity": "sha512-JylOEEzDiOryeUnFbQz+oViCXS0KsvR1mvHkoMiu5+UiBvy+RYX7tzlIIIEstF/gVa2tj9AQXk3dgnxv6KxhFg==",
 			"dev": true,
 			"engines": {
 				"node": "^12.0.0 || ^14.0.0 || >=16.0.0"
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.3.tgz",
-			"integrity": "sha512-+5gy6OQfk+xx3q0d6jGZZC3f3KzAkXc/IanVxd1is/VIIziRqqt3ongQz0FiTUXqTk0c7aDB3OaFuKnuSoJicQ==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.2.tgz",
+			"integrity": "sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==",
 			"dev": true,
 			"dependencies": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
-				"espree": "^9.5.2",
+				"espree": "^9.6.0",
 				"globals": "^13.19.0",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.2.1",
@@ -169,18 +169,18 @@
 			}
 		},
 		"node_modules/@eslint/js": {
-			"version": "8.43.0",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.43.0.tgz",
-			"integrity": "sha512-s2UHCoiXfxMvmfzqoN+vrQ84ahUSYde9qNO1MdxmoEhyHWsfmwOpFlwYV+ePJEVc7gFnATGUi376WowX1N7tFg==",
+			"version": "8.49.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.49.0.tgz",
+			"integrity": "sha512-1S8uAY/MTJqVx0SC4epBq+N2yhuwtNwLbJYNZyhL2pO1ZVKn5HFXav5T41Ryzy9K9V7ZId2JB2oy/W4aCd9/2w==",
 			"dev": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
 		"node_modules/@humanwhocodes/config-array": {
-			"version": "0.11.10",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
-			"integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
+			"version": "0.11.11",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.11.tgz",
+			"integrity": "sha512-N2brEuAadi0CcdeMXUkhbZB84eskAc8MEX1By6qEchoVywSgXPIjou4rYsl0V3Hj0ZnuGycGCjdNgockbzeWNA==",
 			"dev": true,
 			"dependencies": {
 				"@humanwhocodes/object-schema": "^1.2.1",
@@ -504,9 +504,9 @@
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.8.2",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
-			"integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+			"version": "8.10.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+			"integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
 			"dev": true,
 			"bin": {
 				"acorn": "bin/acorn"
@@ -865,27 +865,27 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "8.43.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.43.0.tgz",
-			"integrity": "sha512-aaCpf2JqqKesMFGgmRPessmVKjcGXqdlAYLLC3THM8t5nBRZRQ+st5WM/hoJXkdioEXLLbXgclUpM0TXo5HX5Q==",
+			"version": "8.49.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.49.0.tgz",
+			"integrity": "sha512-jw03ENfm6VJI0jA9U+8H5zfl5b+FvuU3YYvZRdZHOlU2ggJkxrlkJH4HcDrZpj6YwD8kuYqvQM8LyesoazrSOQ==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
-				"@eslint-community/regexpp": "^4.4.0",
-				"@eslint/eslintrc": "^2.0.3",
-				"@eslint/js": "8.43.0",
-				"@humanwhocodes/config-array": "^0.11.10",
+				"@eslint-community/regexpp": "^4.6.1",
+				"@eslint/eslintrc": "^2.1.2",
+				"@eslint/js": "8.49.0",
+				"@humanwhocodes/config-array": "^0.11.11",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@nodelib/fs.walk": "^1.2.8",
-				"ajv": "^6.10.0",
+				"ajv": "^6.12.4",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.2",
 				"debug": "^4.3.2",
 				"doctrine": "^3.0.0",
 				"escape-string-regexp": "^4.0.0",
-				"eslint-scope": "^7.2.0",
-				"eslint-visitor-keys": "^3.4.1",
-				"espree": "^9.5.2",
+				"eslint-scope": "^7.2.2",
+				"eslint-visitor-keys": "^3.4.3",
+				"espree": "^9.6.1",
 				"esquery": "^1.4.2",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
@@ -895,7 +895,6 @@
 				"globals": "^13.19.0",
 				"graphemer": "^1.4.0",
 				"ignore": "^5.2.0",
-				"import-fresh": "^3.0.0",
 				"imurmurhash": "^0.1.4",
 				"is-glob": "^4.0.0",
 				"is-path-inside": "^3.0.3",
@@ -905,9 +904,8 @@
 				"lodash.merge": "^4.6.2",
 				"minimatch": "^3.1.2",
 				"natural-compare": "^1.4.0",
-				"optionator": "^0.9.1",
+				"optionator": "^0.9.3",
 				"strip-ansi": "^6.0.1",
-				"strip-json-comments": "^3.1.0",
 				"text-table": "^0.2.0"
 			},
 			"bin": {
@@ -934,9 +932,9 @@
 			}
 		},
 		"node_modules/eslint-visitor-keys": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
-			"integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
 			"dev": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -946,9 +944,9 @@
 			}
 		},
 		"node_modules/eslint/node_modules/eslint-scope": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
-			"integrity": "sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==",
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+			"integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
 			"dev": true,
 			"dependencies": {
 				"esrecurse": "^4.3.0",
@@ -971,12 +969,12 @@
 			}
 		},
 		"node_modules/espree": {
-			"version": "9.5.2",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-9.5.2.tgz",
-			"integrity": "sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==",
+			"version": "9.6.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+			"integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
 			"dev": true,
 			"dependencies": {
-				"acorn": "^8.8.0",
+				"acorn": "^8.9.0",
 				"acorn-jsx": "^5.3.2",
 				"eslint-visitor-keys": "^3.4.1"
 			},
@@ -1266,9 +1264,9 @@
 			}
 		},
 		"node_modules/globals": {
-			"version": "13.20.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
-			"integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
+			"version": "13.21.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.21.0.tgz",
+			"integrity": "sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==",
 			"dev": true,
 			"dependencies": {
 				"type-fest": "^0.20.2"
@@ -2364,20 +2362,20 @@
 			}
 		},
 		"@eslint-community/regexpp": {
-			"version": "4.5.1",
-			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.1.tgz",
-			"integrity": "sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==",
+			"version": "4.8.0",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.8.0.tgz",
+			"integrity": "sha512-JylOEEzDiOryeUnFbQz+oViCXS0KsvR1mvHkoMiu5+UiBvy+RYX7tzlIIIEstF/gVa2tj9AQXk3dgnxv6KxhFg==",
 			"dev": true
 		},
 		"@eslint/eslintrc": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.3.tgz",
-			"integrity": "sha512-+5gy6OQfk+xx3q0d6jGZZC3f3KzAkXc/IanVxd1is/VIIziRqqt3ongQz0FiTUXqTk0c7aDB3OaFuKnuSoJicQ==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.2.tgz",
+			"integrity": "sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==",
 			"dev": true,
 			"requires": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
-				"espree": "^9.5.2",
+				"espree": "^9.6.0",
 				"globals": "^13.19.0",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.2.1",
@@ -2387,15 +2385,15 @@
 			}
 		},
 		"@eslint/js": {
-			"version": "8.43.0",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.43.0.tgz",
-			"integrity": "sha512-s2UHCoiXfxMvmfzqoN+vrQ84ahUSYde9qNO1MdxmoEhyHWsfmwOpFlwYV+ePJEVc7gFnATGUi376WowX1N7tFg==",
+			"version": "8.49.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.49.0.tgz",
+			"integrity": "sha512-1S8uAY/MTJqVx0SC4epBq+N2yhuwtNwLbJYNZyhL2pO1ZVKn5HFXav5T41Ryzy9K9V7ZId2JB2oy/W4aCd9/2w==",
 			"dev": true
 		},
 		"@humanwhocodes/config-array": {
-			"version": "0.11.10",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
-			"integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
+			"version": "0.11.11",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.11.tgz",
+			"integrity": "sha512-N2brEuAadi0CcdeMXUkhbZB84eskAc8MEX1By6qEchoVywSgXPIjou4rYsl0V3Hj0ZnuGycGCjdNgockbzeWNA==",
 			"dev": true,
 			"requires": {
 				"@humanwhocodes/object-schema": "^1.2.1",
@@ -2595,9 +2593,9 @@
 			"integrity": "sha512-HIzRG7sy88UZjBJamssEczH5q7t5+axva19UbZLO6u0ySbYPrwzWiXBcC0WuHyhKKoeCyneH+FvYzKQq/zTtkQ=="
 		},
 		"acorn": {
-			"version": "8.8.2",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
-			"integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+			"version": "8.10.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+			"integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
 			"dev": true
 		},
 		"acorn-jsx": {
@@ -2867,27 +2865,27 @@
 			"dev": true
 		},
 		"eslint": {
-			"version": "8.43.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.43.0.tgz",
-			"integrity": "sha512-aaCpf2JqqKesMFGgmRPessmVKjcGXqdlAYLLC3THM8t5nBRZRQ+st5WM/hoJXkdioEXLLbXgclUpM0TXo5HX5Q==",
+			"version": "8.49.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.49.0.tgz",
+			"integrity": "sha512-jw03ENfm6VJI0jA9U+8H5zfl5b+FvuU3YYvZRdZHOlU2ggJkxrlkJH4HcDrZpj6YwD8kuYqvQM8LyesoazrSOQ==",
 			"dev": true,
 			"requires": {
 				"@eslint-community/eslint-utils": "^4.2.0",
-				"@eslint-community/regexpp": "^4.4.0",
-				"@eslint/eslintrc": "^2.0.3",
-				"@eslint/js": "8.43.0",
-				"@humanwhocodes/config-array": "^0.11.10",
+				"@eslint-community/regexpp": "^4.6.1",
+				"@eslint/eslintrc": "^2.1.2",
+				"@eslint/js": "8.49.0",
+				"@humanwhocodes/config-array": "^0.11.11",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@nodelib/fs.walk": "^1.2.8",
-				"ajv": "^6.10.0",
+				"ajv": "^6.12.4",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.2",
 				"debug": "^4.3.2",
 				"doctrine": "^3.0.0",
 				"escape-string-regexp": "^4.0.0",
-				"eslint-scope": "^7.2.0",
-				"eslint-visitor-keys": "^3.4.1",
-				"espree": "^9.5.2",
+				"eslint-scope": "^7.2.2",
+				"eslint-visitor-keys": "^3.4.3",
+				"espree": "^9.6.1",
 				"esquery": "^1.4.2",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
@@ -2897,7 +2895,6 @@
 				"globals": "^13.19.0",
 				"graphemer": "^1.4.0",
 				"ignore": "^5.2.0",
-				"import-fresh": "^3.0.0",
 				"imurmurhash": "^0.1.4",
 				"is-glob": "^4.0.0",
 				"is-path-inside": "^3.0.3",
@@ -2907,16 +2904,15 @@
 				"lodash.merge": "^4.6.2",
 				"minimatch": "^3.1.2",
 				"natural-compare": "^1.4.0",
-				"optionator": "^0.9.1",
+				"optionator": "^0.9.3",
 				"strip-ansi": "^6.0.1",
-				"strip-json-comments": "^3.1.0",
 				"text-table": "^0.2.0"
 			},
 			"dependencies": {
 				"eslint-scope": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
-					"integrity": "sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==",
+					"version": "7.2.2",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+					"integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
 					"dev": true,
 					"requires": {
 						"esrecurse": "^4.3.0",
@@ -2942,18 +2938,18 @@
 			}
 		},
 		"eslint-visitor-keys": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
-			"integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
 			"dev": true
 		},
 		"espree": {
-			"version": "9.5.2",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-9.5.2.tgz",
-			"integrity": "sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==",
+			"version": "9.6.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+			"integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
 			"dev": true,
 			"requires": {
-				"acorn": "^8.8.0",
+				"acorn": "^8.9.0",
 				"acorn-jsx": "^5.3.2",
 				"eslint-visitor-keys": "^3.4.1"
 			}
@@ -3180,9 +3176,9 @@
 			}
 		},
 		"globals": {
-			"version": "13.20.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
-			"integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
+			"version": "13.21.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.21.0.tgz",
+			"integrity": "sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==",
 			"dev": true,
 			"requires": {
 				"type-fest": "^0.20.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -915,19 +915,7 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
-		"node_modules/eslint-visitor-keys": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-			"dev": true,
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/eslint/node_modules/eslint-scope": {
+		"node_modules/eslint-scope": {
 			"version": "7.2.2",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
 			"integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
@@ -943,13 +931,16 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
-		"node_modules/eslint/node_modules/estraverse": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+		"node_modules/eslint-visitor-keys": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
 			"dev": true,
 			"engines": {
-				"node": ">=4.0"
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/espree": {
@@ -981,15 +972,6 @@
 				"node": ">=0.10"
 			}
 		},
-		"node_modules/esquery/node_modules/estraverse": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-			"dev": true,
-			"engines": {
-				"node": ">=4.0"
-			}
-		},
 		"node_modules/esrecurse": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
@@ -1002,7 +984,7 @@
 				"node": ">=4.0"
 			}
 		},
-		"node_modules/esrecurse/node_modules/estraverse": {
+		"node_modules/estraverse": {
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
 			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
@@ -1120,16 +1102,17 @@
 			}
 		},
 		"node_modules/flat-cache": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
-			"integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.1.0.tgz",
+			"integrity": "sha512-OHx4Qwrrt0E4jEIcI5/Xb+f+QmJYNj2rrK8wiIdQOIrB9WrrJL8cjZvXdXuBTkkEwEqLycb5BeZDV1o2i9bTew==",
 			"dev": true,
 			"dependencies": {
-				"flatted": "^3.1.0",
+				"flatted": "^3.2.7",
+				"keyv": "^4.5.3",
 				"rimraf": "^3.0.2"
 			},
 			"engines": {
-				"node": "^10.12.0 || >=12.0.0"
+				"node": ">=12.0.0"
 			}
 		},
 		"node_modules/flatted": {
@@ -1425,6 +1408,12 @@
 				"js-yaml": "bin/js-yaml.js"
 			}
 		},
+		"node_modules/json-buffer": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+			"dev": true
+		},
 		"node_modules/json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -1436,6 +1425,15 @@
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
 			"dev": true
+		},
+		"node_modules/keyv": {
+			"version": "4.5.3",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.3.tgz",
+			"integrity": "sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==",
+			"dev": true,
+			"dependencies": {
+				"json-buffer": "3.0.1"
+			}
 		},
 		"node_modules/levn": {
 			"version": "0.4.1",
@@ -1912,9 +1910,9 @@
 			}
 		},
 		"node_modules/superagent": {
-			"version": "8.0.9",
-			"resolved": "https://registry.npmjs.org/superagent/-/superagent-8.0.9.tgz",
-			"integrity": "sha512-4C7Bh5pyHTvU33KpZgwrNKh/VQnvgtCSqPRfJAUdmrtSYePVzVg4E4OzsrbkhJj9O7SO6Bnv75K/F8XVZT8YHA==",
+			"version": "8.1.2",
+			"resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
+			"integrity": "sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==",
 			"dependencies": {
 				"component-emitter": "^1.3.0",
 				"cookiejar": "^2.1.4",
@@ -2725,24 +2723,16 @@
 				"optionator": "^0.9.3",
 				"strip-ansi": "^6.0.1",
 				"text-table": "^0.2.0"
-			},
-			"dependencies": {
-				"eslint-scope": {
-					"version": "7.2.2",
-					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
-					"integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
-					"dev": true,
-					"requires": {
-						"esrecurse": "^4.3.0",
-						"estraverse": "^5.2.0"
-					}
-				},
-				"estraverse": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-					"dev": true
-				}
+			}
+		},
+		"eslint-scope": {
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+			"integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+			"dev": true,
+			"requires": {
+				"esrecurse": "^4.3.0",
+				"estraverse": "^5.2.0"
 			}
 		},
 		"eslint-visitor-keys": {
@@ -2769,14 +2759,6 @@
 			"dev": true,
 			"requires": {
 				"estraverse": "^5.1.0"
-			},
-			"dependencies": {
-				"estraverse": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-					"dev": true
-				}
 			}
 		},
 		"esrecurse": {
@@ -2786,15 +2768,13 @@
 			"dev": true,
 			"requires": {
 				"estraverse": "^5.2.0"
-			},
-			"dependencies": {
-				"estraverse": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-					"dev": true
-				}
 			}
+		},
+		"estraverse": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+			"dev": true
 		},
 		"esutils": {
 			"version": "2.0.3",
@@ -2886,12 +2866,13 @@
 			}
 		},
 		"flat-cache": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
-			"integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.1.0.tgz",
+			"integrity": "sha512-OHx4Qwrrt0E4jEIcI5/Xb+f+QmJYNj2rrK8wiIdQOIrB9WrrJL8cjZvXdXuBTkkEwEqLycb5BeZDV1o2i9bTew==",
 			"dev": true,
 			"requires": {
-				"flatted": "^3.1.0",
+				"flatted": "^3.2.7",
+				"keyv": "^4.5.3",
 				"rimraf": "^3.0.2"
 			}
 		},
@@ -3110,6 +3091,12 @@
 				"argparse": "^2.0.1"
 			}
 		},
+		"json-buffer": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+			"dev": true
+		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -3121,6 +3108,15 @@
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
 			"dev": true
+		},
+		"keyv": {
+			"version": "4.5.3",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.3.tgz",
+			"integrity": "sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==",
+			"dev": true,
+			"requires": {
+				"json-buffer": "3.0.1"
+			}
 		},
 		"levn": {
 			"version": "0.4.1",
@@ -3439,9 +3435,9 @@
 			"dev": true
 		},
 		"superagent": {
-			"version": "8.0.9",
-			"resolved": "https://registry.npmjs.org/superagent/-/superagent-8.0.9.tgz",
-			"integrity": "sha512-4C7Bh5pyHTvU33KpZgwrNKh/VQnvgtCSqPRfJAUdmrtSYePVzVg4E4OzsrbkhJj9O7SO6Bnv75K/F8XVZT8YHA==",
+			"version": "8.1.2",
+			"resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
+			"integrity": "sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==",
 			"requires": {
 				"component-emitter": "^1.3.0",
 				"cookiejar": "^2.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "discord-cleverbot",
 			"version": "5.0.0",
 			"dependencies": {
-				"@colors/colors": "^1.5.0",
+				"@colors/colors": "^1.6.0",
 				"cleverbot-free": "^2.0.0",
 				"discord.js": "^14.11.0",
 				"dotenv": "^16.3.1"
@@ -33,9 +33,9 @@
 			}
 		},
 		"node_modules/@colors/colors": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
-			"integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+			"integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
 			"engines": {
 				"node": ">=0.1.90"
 			}
@@ -2287,9 +2287,9 @@
 			"dev": true
 		},
 		"@colors/colors": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
-			"integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+			"integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA=="
 		},
 		"@discordjs/builders": {
 			"version": "1.6.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"dependencies": {
 				"@colors/colors": "^1.6.0",
 				"cleverbot-free": "^2.0.0",
-				"discord.js": "^14.11.0",
+				"discord.js": "^14.13.0",
 				"dotenv": "^16.3.1"
 			},
 			"devDependencies": {
@@ -41,84 +41,85 @@
 			}
 		},
 		"node_modules/@discordjs/builders": {
-			"version": "1.6.3",
-			"resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.6.3.tgz",
-			"integrity": "sha512-CTCh8NqED3iecTNuiz49mwSsrc2iQb4d0MjMdmS/8pb69Y4IlzJ/DIy/p5GFlgOrFbNO2WzMHkWKQSiJ3VNXaw==",
+			"version": "1.6.5",
+			"resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.6.5.tgz",
+			"integrity": "sha512-SdweyCs/+mHj+PNhGLLle7RrRFX9ZAhzynHahMCLqp5Zeq7np7XC6/mgzHc79QoVlQ1zZtOkTTiJpOZu5V8Ufg==",
 			"dependencies": {
-				"@discordjs/formatters": "^0.3.1",
-				"@discordjs/util": "^0.3.1",
-				"@sapphire/shapeshift": "^3.8.2",
-				"discord-api-types": "^0.37.41",
+				"@discordjs/formatters": "^0.3.2",
+				"@discordjs/util": "^1.0.1",
+				"@sapphire/shapeshift": "^3.9.2",
+				"discord-api-types": "0.37.50",
 				"fast-deep-equal": "^3.1.3",
 				"ts-mixer": "^6.0.3",
-				"tslib": "^2.5.0"
+				"tslib": "^2.6.1"
 			},
 			"engines": {
-				"node": ">=16.9.0"
+				"node": ">=16.11.0"
 			}
 		},
 		"node_modules/@discordjs/collection": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.1.tgz",
-			"integrity": "sha512-aWEc9DCf3TMDe9iaJoOnO2+JVAjeRNuRxPZQA6GVvBf+Z3gqUuWYBy2NWh4+5CLYq5uoc3MOvUQ5H5m8CJBqOA==",
+			"version": "1.5.3",
+			"resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
+			"integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==",
 			"engines": {
-				"node": ">=16.9.0"
+				"node": ">=16.11.0"
 			}
 		},
 		"node_modules/@discordjs/formatters": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.3.1.tgz",
-			"integrity": "sha512-M7X4IGiSeh4znwcRGcs+49B5tBkNDn4k5bmhxJDAUhRxRHTiFAOTVUNQ6yAKySu5jZTnCbSvTYHW3w0rAzV1MA==",
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.3.2.tgz",
+			"integrity": "sha512-lE++JZK8LSSDRM5nLjhuvWhGuKiXqu+JZ/DsOR89DVVia3z9fdCJVcHF2W/1Zxgq0re7kCzmAJlCMMX3tetKpA==",
 			"dependencies": {
-				"discord-api-types": "^0.37.41"
+				"discord-api-types": "0.37.50"
 			},
 			"engines": {
-				"node": ">=16.9.0"
+				"node": ">=16.11.0"
 			}
 		},
 		"node_modules/@discordjs/rest": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-1.7.1.tgz",
-			"integrity": "sha512-Ofa9UqT0U45G/eX86cURQnX7gzOJLG2oC28VhIk/G6IliYgQF7jFByBJEykPSHE4MxPhqCleYvmsrtfKh1nYmQ==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.0.1.tgz",
+			"integrity": "sha512-/eWAdDRvwX/rIE2tuQUmKaxmWeHmGealttIzGzlYfI4+a7y9b6ZoMp8BG/jaohs8D8iEnCNYaZiOFLVFLQb8Zg==",
 			"dependencies": {
-				"@discordjs/collection": "^1.5.1",
-				"@discordjs/util": "^0.3.0",
+				"@discordjs/collection": "^1.5.3",
+				"@discordjs/util": "^1.0.1",
 				"@sapphire/async-queue": "^1.5.0",
-				"@sapphire/snowflake": "^3.4.2",
-				"discord-api-types": "^0.37.41",
-				"file-type": "^18.3.0",
-				"tslib": "^2.5.0",
-				"undici": "^5.22.0"
+				"@sapphire/snowflake": "^3.5.1",
+				"@vladfrangu/async_event_emitter": "^2.2.2",
+				"discord-api-types": "0.37.50",
+				"magic-bytes.js": "^1.0.15",
+				"tslib": "^2.6.1",
+				"undici": "5.22.1"
 			},
 			"engines": {
-				"node": ">=16.9.0"
+				"node": ">=16.11.0"
 			}
 		},
 		"node_modules/@discordjs/util": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/@discordjs/util/-/util-0.3.1.tgz",
-			"integrity": "sha512-HxXKYKg7vohx2/OupUN/4Sd02Ev3PBJ5q0gtjdcvXb0ErCva8jNHWfe/v5sU3UKjIB/uxOhc+TDOnhqffj9pRA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.0.1.tgz",
+			"integrity": "sha512-d0N2yCxB8r4bn00/hvFZwM7goDcUhtViC5un4hPj73Ba4yrChLSJD8fy7Ps5jpTLg1fE9n4K0xBLc1y9WGwSsA==",
 			"engines": {
-				"node": ">=16.9.0"
+				"node": ">=16.11.0"
 			}
 		},
 		"node_modules/@discordjs/ws": {
-			"version": "0.8.3",
-			"resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-0.8.3.tgz",
-			"integrity": "sha512-hcYtppanjHecbdNyCKQNH2I4RP9UrphDgmRgLYrATEQF1oo4sYSve7ZmGsBEXSzH72MO2tBPdWSThunbxUVk0g==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.0.1.tgz",
+			"integrity": "sha512-avvAolBqN3yrSvdBPcJ/0j2g42ABzrv3PEL76e3YTp2WYMGH7cuspkjfSyNWaqYl1J+669dlLp+YFMxSVQyS5g==",
 			"dependencies": {
-				"@discordjs/collection": "^1.5.1",
-				"@discordjs/rest": "^1.7.1",
-				"@discordjs/util": "^0.3.1",
+				"@discordjs/collection": "^1.5.3",
+				"@discordjs/rest": "^2.0.1",
+				"@discordjs/util": "^1.0.1",
 				"@sapphire/async-queue": "^1.5.0",
-				"@types/ws": "^8.5.4",
-				"@vladfrangu/async_event_emitter": "^2.2.1",
-				"discord-api-types": "^0.37.41",
-				"tslib": "^2.5.0",
+				"@types/ws": "^8.5.5",
+				"@vladfrangu/async_event_emitter": "^2.2.2",
+				"discord-api-types": "0.37.50",
+				"tslib": "^2.6.1",
 				"ws": "^8.13.0"
 			},
 			"engines": {
-				"node": ">=16.9.0"
+				"node": ">=16.11.0"
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {
@@ -276,11 +277,6 @@
 				"npm": ">=7.0.0"
 			}
 		},
-		"node_modules/@tokenizer/token": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
-			"integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
-		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.12",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
@@ -288,9 +284,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "18.16.16",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.16.tgz",
-			"integrity": "sha512-NpaM49IGQQAUlBhHMF82QH80J08os4ZmyF9MkpCzWAGuOHqE4gTEbhzd7L3l5LmWuZ6E0OiC1FweQ4tsiW35+g=="
+			"version": "20.6.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.6.0.tgz",
+			"integrity": "sha512-najjVq5KN2vsH2U/xyh2opaSEz6cZMR2SetLIlxlj08nOcmPOemJmUK2o4kUzfLqfrWE0PIrNeE16XhYDd3nqg=="
 		},
 		"node_modules/@types/semver": {
 			"version": "7.5.1",
@@ -802,32 +798,32 @@
 			}
 		},
 		"node_modules/discord-api-types": {
-			"version": "0.37.43",
-			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.43.tgz",
-			"integrity": "sha512-bBhDWU3TF9KADxR/mHp1K4Bvu/LRtFQdGyBjADu4e66F3ZnD4kp12W/SJCttIaCcMXzPV3sfty6eDGRNRph51Q=="
+			"version": "0.37.50",
+			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.50.tgz",
+			"integrity": "sha512-X4CDiMnDbA3s3RaUXWXmgAIbY1uxab3fqe3qwzg5XutR3wjqi7M3IkgQbsIBzpqBN2YWr/Qdv7JrFRqSgb4TFg=="
 		},
 		"node_modules/discord.js": {
-			"version": "14.11.0",
-			"resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.11.0.tgz",
-			"integrity": "sha512-CkueWYFQ28U38YPR8HgsBR/QT35oPpMbEsTNM30Fs8loBIhnA4s70AwQEoy6JvLcpWWJO7GY0y2BUzZmuBMepQ==",
+			"version": "14.13.0",
+			"resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.13.0.tgz",
+			"integrity": "sha512-Kufdvg7fpyTEwANGy9x7i4od4yu5c6gVddGi5CKm4Y5a6sF0VBODObI3o0Bh7TGCj0LfNT8Qp8z04wnLFzgnbA==",
 			"dependencies": {
-				"@discordjs/builders": "^1.6.3",
-				"@discordjs/collection": "^1.5.1",
-				"@discordjs/formatters": "^0.3.1",
-				"@discordjs/rest": "^1.7.1",
-				"@discordjs/util": "^0.3.1",
-				"@discordjs/ws": "^0.8.3",
-				"@sapphire/snowflake": "^3.4.2",
-				"@types/ws": "^8.5.4",
-				"discord-api-types": "^0.37.41",
+				"@discordjs/builders": "^1.6.5",
+				"@discordjs/collection": "^1.5.3",
+				"@discordjs/formatters": "^0.3.2",
+				"@discordjs/rest": "^2.0.1",
+				"@discordjs/util": "^1.0.1",
+				"@discordjs/ws": "^1.0.1",
+				"@sapphire/snowflake": "^3.5.1",
+				"@types/ws": "^8.5.5",
+				"discord-api-types": "0.37.50",
 				"fast-deep-equal": "^3.1.3",
 				"lodash.snakecase": "^4.1.1",
-				"tslib": "^2.5.0",
-				"undici": "^5.22.0",
+				"tslib": "^2.6.1",
+				"undici": "5.22.1",
 				"ws": "^8.13.0"
 			},
 			"engines": {
-				"node": ">=16.9.0"
+				"node": ">=16.11.0"
 			}
 		},
 		"node_modules/doctrine": {
@@ -1095,22 +1091,6 @@
 				"node": "^10.12.0 || >=12.0.0"
 			}
 		},
-		"node_modules/file-type": {
-			"version": "18.5.0",
-			"resolved": "https://registry.npmjs.org/file-type/-/file-type-18.5.0.tgz",
-			"integrity": "sha512-yvpl5U868+V6PqXHMmsESpg6unQ5GfnPssl4dxdJudBrr9qy7Fddt7EVX1VLlddFfe8Gj9N7goCZH22FXuSQXQ==",
-			"dependencies": {
-				"readable-web-to-node-stream": "^3.0.2",
-				"strtok3": "^7.0.0",
-				"token-types": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"url": "https://github.com/sindresorhus/file-type?sponsor=1"
-			}
-		},
 		"node_modules/fill-range": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -1333,25 +1313,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/ieee754": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			]
-		},
 		"node_modules/ignore": {
 			"version": "5.2.4",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
@@ -1399,7 +1360,8 @@
 		"node_modules/inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true
 		},
 		"node_modules/is-buffer": {
 			"version": "1.1.6",
@@ -1529,6 +1491,11 @@
 			"engines": {
 				"node": ">=10"
 			}
+		},
+		"node_modules/magic-bytes.js": {
+			"version": "1.0.15",
+			"resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.0.15.tgz",
+			"integrity": "sha512-bpRmwbRHqongRhA+mXzbLWjVy7ylqmfMBYaQkSs6pac0z6hBTvsgrH0r4FBYd/UYVJBmS6Rp/O+oCCQVLzKV1g=="
 		},
 		"node_modules/md5": {
 			"version": "2.3.0",
@@ -1734,18 +1701,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/peek-readable": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-5.0.0.tgz",
-			"integrity": "sha512-YtCKvLUOvwtMGmrniQPdO7MwPjgkFBtFIrmfSbYmYuq3tKDV/mcfAhBth1+C3ru7uXIZasc/pHnb+YDYNkkj4A==",
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/Borewit"
-			}
-		},
 		"node_modules/picomatch": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -1810,34 +1765,6 @@
 				}
 			]
 		},
-		"node_modules/readable-stream": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/readable-web-to-node-stream": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
-			"integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
-			"dependencies": {
-				"readable-stream": "^3.6.0"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/Borewit"
-			}
-		},
 		"node_modules/resolve-from": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -1894,25 +1821,6 @@
 			"dependencies": {
 				"queue-microtask": "^1.2.2"
 			}
-		},
-		"node_modules/safe-buffer": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			]
 		},
 		"node_modules/semver": {
 			"version": "7.5.4",
@@ -1979,14 +1887,6 @@
 				"node": ">=10.0.0"
 			}
 		},
-		"node_modules/string_decoder": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-			"dependencies": {
-				"safe-buffer": "~5.2.0"
-			}
-		},
 		"node_modules/strip-ansi": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -2009,22 +1909,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/strtok3": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-7.0.0.tgz",
-			"integrity": "sha512-pQ+V+nYQdC5H3Q7qBZAz/MO6lwGhoC2gOAjuouGf/VO0m7vQRh8QNMl2Uf6SwAtzZ9bOw3UIeBukEGNJl5dtXQ==",
-			"dependencies": {
-				"@tokenizer/token": "^0.3.0",
-				"peek-readable": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/Borewit"
 			}
 		},
 		"node_modules/superagent": {
@@ -2077,22 +1961,6 @@
 				"node": ">=8.0"
 			}
 		},
-		"node_modules/token-types": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/token-types/-/token-types-5.0.1.tgz",
-			"integrity": "sha512-Y2fmSnZjQdDb9W4w4r1tswlMHylzWIeOKpx0aZH9BgGtACHhrk3OkT52AzwcuqTRBZtvvnTjDBh8eynMulu8Vg==",
-			"dependencies": {
-				"@tokenizer/token": "^0.3.0",
-				"ieee754": "^1.2.1"
-			},
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/Borewit"
-			}
-		},
 		"node_modules/ts-api-utils": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
@@ -2111,9 +1979,9 @@
 			"integrity": "sha512-k43M7uCG1AkTyxgnmI5MPwKoUvS/bRvLvUb7+Pgpdlmok8AoqmUaZxUUw8zKM5B1lqZrt41GjYgnvAi0fppqgQ=="
 		},
 		"node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
@@ -2172,11 +2040,6 @@
 				"punycode": "^2.1.0"
 			}
 		},
-		"node_modules/util-deprecate": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
-		},
 		"node_modules/which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2198,9 +2061,9 @@
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
 		},
 		"node_modules/ws": {
-			"version": "8.13.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-			"integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+			"version": "8.14.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.14.1.tgz",
+			"integrity": "sha512-4OOseMUq8AzRBI/7SLMUwO+FEDnguetSk7KMb1sHwvF2w2Wv5Hoj0nlifx8vtGsftE/jWHojPy8sMMzYLJ2G/A==",
 			"engines": {
 				"node": ">=10.0.0"
 			},
@@ -2248,65 +2111,66 @@
 			"integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA=="
 		},
 		"@discordjs/builders": {
-			"version": "1.6.3",
-			"resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.6.3.tgz",
-			"integrity": "sha512-CTCh8NqED3iecTNuiz49mwSsrc2iQb4d0MjMdmS/8pb69Y4IlzJ/DIy/p5GFlgOrFbNO2WzMHkWKQSiJ3VNXaw==",
+			"version": "1.6.5",
+			"resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.6.5.tgz",
+			"integrity": "sha512-SdweyCs/+mHj+PNhGLLle7RrRFX9ZAhzynHahMCLqp5Zeq7np7XC6/mgzHc79QoVlQ1zZtOkTTiJpOZu5V8Ufg==",
 			"requires": {
-				"@discordjs/formatters": "^0.3.1",
-				"@discordjs/util": "^0.3.1",
-				"@sapphire/shapeshift": "^3.8.2",
-				"discord-api-types": "^0.37.41",
+				"@discordjs/formatters": "^0.3.2",
+				"@discordjs/util": "^1.0.1",
+				"@sapphire/shapeshift": "^3.9.2",
+				"discord-api-types": "0.37.50",
 				"fast-deep-equal": "^3.1.3",
 				"ts-mixer": "^6.0.3",
-				"tslib": "^2.5.0"
+				"tslib": "^2.6.1"
 			}
 		},
 		"@discordjs/collection": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.1.tgz",
-			"integrity": "sha512-aWEc9DCf3TMDe9iaJoOnO2+JVAjeRNuRxPZQA6GVvBf+Z3gqUuWYBy2NWh4+5CLYq5uoc3MOvUQ5H5m8CJBqOA=="
+			"version": "1.5.3",
+			"resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
+			"integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ=="
 		},
 		"@discordjs/formatters": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.3.1.tgz",
-			"integrity": "sha512-M7X4IGiSeh4znwcRGcs+49B5tBkNDn4k5bmhxJDAUhRxRHTiFAOTVUNQ6yAKySu5jZTnCbSvTYHW3w0rAzV1MA==",
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.3.2.tgz",
+			"integrity": "sha512-lE++JZK8LSSDRM5nLjhuvWhGuKiXqu+JZ/DsOR89DVVia3z9fdCJVcHF2W/1Zxgq0re7kCzmAJlCMMX3tetKpA==",
 			"requires": {
-				"discord-api-types": "^0.37.41"
+				"discord-api-types": "0.37.50"
 			}
 		},
 		"@discordjs/rest": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-1.7.1.tgz",
-			"integrity": "sha512-Ofa9UqT0U45G/eX86cURQnX7gzOJLG2oC28VhIk/G6IliYgQF7jFByBJEykPSHE4MxPhqCleYvmsrtfKh1nYmQ==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.0.1.tgz",
+			"integrity": "sha512-/eWAdDRvwX/rIE2tuQUmKaxmWeHmGealttIzGzlYfI4+a7y9b6ZoMp8BG/jaohs8D8iEnCNYaZiOFLVFLQb8Zg==",
 			"requires": {
-				"@discordjs/collection": "^1.5.1",
-				"@discordjs/util": "^0.3.0",
+				"@discordjs/collection": "^1.5.3",
+				"@discordjs/util": "^1.0.1",
 				"@sapphire/async-queue": "^1.5.0",
-				"@sapphire/snowflake": "^3.4.2",
-				"discord-api-types": "^0.37.41",
-				"file-type": "^18.3.0",
-				"tslib": "^2.5.0",
-				"undici": "^5.22.0"
+				"@sapphire/snowflake": "^3.5.1",
+				"@vladfrangu/async_event_emitter": "^2.2.2",
+				"discord-api-types": "0.37.50",
+				"magic-bytes.js": "^1.0.15",
+				"tslib": "^2.6.1",
+				"undici": "5.22.1"
 			}
 		},
 		"@discordjs/util": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/@discordjs/util/-/util-0.3.1.tgz",
-			"integrity": "sha512-HxXKYKg7vohx2/OupUN/4Sd02Ev3PBJ5q0gtjdcvXb0ErCva8jNHWfe/v5sU3UKjIB/uxOhc+TDOnhqffj9pRA=="
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.0.1.tgz",
+			"integrity": "sha512-d0N2yCxB8r4bn00/hvFZwM7goDcUhtViC5un4hPj73Ba4yrChLSJD8fy7Ps5jpTLg1fE9n4K0xBLc1y9WGwSsA=="
 		},
 		"@discordjs/ws": {
-			"version": "0.8.3",
-			"resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-0.8.3.tgz",
-			"integrity": "sha512-hcYtppanjHecbdNyCKQNH2I4RP9UrphDgmRgLYrATEQF1oo4sYSve7ZmGsBEXSzH72MO2tBPdWSThunbxUVk0g==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.0.1.tgz",
+			"integrity": "sha512-avvAolBqN3yrSvdBPcJ/0j2g42ABzrv3PEL76e3YTp2WYMGH7cuspkjfSyNWaqYl1J+669dlLp+YFMxSVQyS5g==",
 			"requires": {
-				"@discordjs/collection": "^1.5.1",
-				"@discordjs/rest": "^1.7.1",
-				"@discordjs/util": "^0.3.1",
+				"@discordjs/collection": "^1.5.3",
+				"@discordjs/rest": "^2.0.1",
+				"@discordjs/util": "^1.0.1",
 				"@sapphire/async-queue": "^1.5.0",
-				"@types/ws": "^8.5.4",
-				"@vladfrangu/async_event_emitter": "^2.2.1",
-				"discord-api-types": "^0.37.41",
-				"tslib": "^2.5.0",
+				"@types/ws": "^8.5.5",
+				"@vladfrangu/async_event_emitter": "^2.2.2",
+				"discord-api-types": "0.37.50",
+				"tslib": "^2.6.1",
 				"ws": "^8.13.0"
 			}
 		},
@@ -2416,11 +2280,6 @@
 			"resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.1.tgz",
 			"integrity": "sha512-BxcYGzgEsdlG0dKAyOm0ehLGm2CafIrfQTZGWgkfKYbj+pNNsorZ7EotuZukc2MT70E0UbppVbtpBrqpzVzjNA=="
 		},
-		"@tokenizer/token": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
-			"integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
-		},
 		"@types/json-schema": {
 			"version": "7.0.12",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
@@ -2428,9 +2287,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "18.16.16",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.16.tgz",
-			"integrity": "sha512-NpaM49IGQQAUlBhHMF82QH80J08os4ZmyF9MkpCzWAGuOHqE4gTEbhzd7L3l5LmWuZ6E0OiC1FweQ4tsiW35+g=="
+			"version": "20.6.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.6.0.tgz",
+			"integrity": "sha512-najjVq5KN2vsH2U/xyh2opaSEz6cZMR2SetLIlxlj08nOcmPOemJmUK2o4kUzfLqfrWE0PIrNeE16XhYDd3nqg=="
 		},
 		"@types/semver": {
 			"version": "7.5.1",
@@ -2778,28 +2637,28 @@
 			}
 		},
 		"discord-api-types": {
-			"version": "0.37.43",
-			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.43.tgz",
-			"integrity": "sha512-bBhDWU3TF9KADxR/mHp1K4Bvu/LRtFQdGyBjADu4e66F3ZnD4kp12W/SJCttIaCcMXzPV3sfty6eDGRNRph51Q=="
+			"version": "0.37.50",
+			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.50.tgz",
+			"integrity": "sha512-X4CDiMnDbA3s3RaUXWXmgAIbY1uxab3fqe3qwzg5XutR3wjqi7M3IkgQbsIBzpqBN2YWr/Qdv7JrFRqSgb4TFg=="
 		},
 		"discord.js": {
-			"version": "14.11.0",
-			"resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.11.0.tgz",
-			"integrity": "sha512-CkueWYFQ28U38YPR8HgsBR/QT35oPpMbEsTNM30Fs8loBIhnA4s70AwQEoy6JvLcpWWJO7GY0y2BUzZmuBMepQ==",
+			"version": "14.13.0",
+			"resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.13.0.tgz",
+			"integrity": "sha512-Kufdvg7fpyTEwANGy9x7i4od4yu5c6gVddGi5CKm4Y5a6sF0VBODObI3o0Bh7TGCj0LfNT8Qp8z04wnLFzgnbA==",
 			"requires": {
-				"@discordjs/builders": "^1.6.3",
-				"@discordjs/collection": "^1.5.1",
-				"@discordjs/formatters": "^0.3.1",
-				"@discordjs/rest": "^1.7.1",
-				"@discordjs/util": "^0.3.1",
-				"@discordjs/ws": "^0.8.3",
-				"@sapphire/snowflake": "^3.4.2",
-				"@types/ws": "^8.5.4",
-				"discord-api-types": "^0.37.41",
+				"@discordjs/builders": "^1.6.5",
+				"@discordjs/collection": "^1.5.3",
+				"@discordjs/formatters": "^0.3.2",
+				"@discordjs/rest": "^2.0.1",
+				"@discordjs/util": "^1.0.1",
+				"@discordjs/ws": "^1.0.1",
+				"@sapphire/snowflake": "^3.5.1",
+				"@types/ws": "^8.5.5",
+				"discord-api-types": "0.37.50",
 				"fast-deep-equal": "^3.1.3",
 				"lodash.snakecase": "^4.1.1",
-				"tslib": "^2.5.0",
-				"undici": "^5.22.0",
+				"tslib": "^2.6.1",
+				"undici": "5.22.1",
 				"ws": "^8.13.0"
 			}
 		},
@@ -3007,16 +2866,6 @@
 				"flat-cache": "^3.0.4"
 			}
 		},
-		"file-type": {
-			"version": "18.5.0",
-			"resolved": "https://registry.npmjs.org/file-type/-/file-type-18.5.0.tgz",
-			"integrity": "sha512-yvpl5U868+V6PqXHMmsESpg6unQ5GfnPssl4dxdJudBrr9qy7Fddt7EVX1VLlddFfe8Gj9N7goCZH22FXuSQXQ==",
-			"requires": {
-				"readable-web-to-node-stream": "^3.0.2",
-				"strtok3": "^7.0.0",
-				"token-types": "^5.0.1"
-			}
-		},
 		"fill-range": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -3176,11 +3025,6 @@
 			"resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
 			"integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g=="
 		},
-		"ieee754": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
-		},
 		"ignore": {
 			"version": "5.2.4",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
@@ -3216,7 +3060,8 @@
 		"inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true
 		},
 		"is-buffer": {
 			"version": "1.1.6",
@@ -3319,6 +3164,11 @@
 			"requires": {
 				"yallist": "^4.0.0"
 			}
+		},
+		"magic-bytes.js": {
+			"version": "1.0.15",
+			"resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.0.15.tgz",
+			"integrity": "sha512-bpRmwbRHqongRhA+mXzbLWjVy7ylqmfMBYaQkSs6pac0z6hBTvsgrH0r4FBYd/UYVJBmS6Rp/O+oCCQVLzKV1g=="
 		},
 		"md5": {
 			"version": "2.3.0",
@@ -3467,11 +3317,6 @@
 			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
 			"dev": true
 		},
-		"peek-readable": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-5.0.0.tgz",
-			"integrity": "sha512-YtCKvLUOvwtMGmrniQPdO7MwPjgkFBtFIrmfSbYmYuq3tKDV/mcfAhBth1+C3ru7uXIZasc/pHnb+YDYNkkj4A=="
-		},
 		"picomatch": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -3504,24 +3349,6 @@
 			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
 			"dev": true
 		},
-		"readable-stream": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-			"requires": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
-			}
-		},
-		"readable-web-to-node-stream": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
-			"integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
-			"requires": {
-				"readable-stream": "^3.6.0"
-			}
-		},
 		"resolve-from": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3551,11 +3378,6 @@
 			"requires": {
 				"queue-microtask": "^1.2.2"
 			}
-		},
-		"safe-buffer": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
 		},
 		"semver": {
 			"version": "7.5.4",
@@ -3601,14 +3423,6 @@
 			"resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
 			"integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
 		},
-		"string_decoder": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-			"requires": {
-				"safe-buffer": "~5.2.0"
-			}
-		},
 		"strip-ansi": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -3623,15 +3437,6 @@
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
 			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
 			"dev": true
-		},
-		"strtok3": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-7.0.0.tgz",
-			"integrity": "sha512-pQ+V+nYQdC5H3Q7qBZAz/MO6lwGhoC2gOAjuouGf/VO0m7vQRh8QNMl2Uf6SwAtzZ9bOw3UIeBukEGNJl5dtXQ==",
-			"requires": {
-				"@tokenizer/token": "^0.3.0",
-				"peek-readable": "^5.0.0"
-			}
 		},
 		"superagent": {
 			"version": "8.0.9",
@@ -3674,15 +3479,6 @@
 				"is-number": "^7.0.0"
 			}
 		},
-		"token-types": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/token-types/-/token-types-5.0.1.tgz",
-			"integrity": "sha512-Y2fmSnZjQdDb9W4w4r1tswlMHylzWIeOKpx0aZH9BgGtACHhrk3OkT52AzwcuqTRBZtvvnTjDBh8eynMulu8Vg==",
-			"requires": {
-				"@tokenizer/token": "^0.3.0",
-				"ieee754": "^1.2.1"
-			}
-		},
 		"ts-api-utils": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
@@ -3696,9 +3492,9 @@
 			"integrity": "sha512-k43M7uCG1AkTyxgnmI5MPwKoUvS/bRvLvUb7+Pgpdlmok8AoqmUaZxUUw8zKM5B1lqZrt41GjYgnvAi0fppqgQ=="
 		},
 		"tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"type-check": {
 			"version": "0.4.0",
@@ -3738,11 +3534,6 @@
 				"punycode": "^2.1.0"
 			}
 		},
-		"util-deprecate": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
-		},
 		"which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3758,9 +3549,9 @@
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
 		},
 		"ws": {
-			"version": "8.13.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-			"integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+			"version": "8.14.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.14.1.tgz",
+			"integrity": "sha512-4OOseMUq8AzRBI/7SLMUwO+FEDnguetSk7KMb1sHwvF2w2Wv5Hoj0nlifx8vtGsftE/jWHojPy8sMMzYLJ2G/A==",
 			"requires": {}
 		},
 		"yallist": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,8 @@
 				"dotenv": "^16.3.1"
 			},
 			"devDependencies": {
-				"@typescript-eslint/eslint-plugin": "^5.59.11",
-				"@typescript-eslint/parser": "^5.59.11",
+				"@typescript-eslint/eslint-plugin": "^6.6.0",
+				"@typescript-eslint/parser": "^6.6.0",
 				"eslint": "^8.49.0",
 				"typescript": "^5.2.2"
 			},
@@ -293,9 +293,9 @@
 			"integrity": "sha512-NpaM49IGQQAUlBhHMF82QH80J08os4ZmyF9MkpCzWAGuOHqE4gTEbhzd7L3l5LmWuZ6E0OiC1FweQ4tsiW35+g=="
 		},
 		"node_modules/@types/semver": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
-			"integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
+			"version": "7.5.1",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.1.tgz",
+			"integrity": "sha512-cJRQXpObxfNKkFAZbJl2yjWtJCqELQIdShsogr1d2MilP8dKD9TE/nEKHkJgUNHdGKCQaf9HbIynuV2csLGVLg==",
 			"dev": true
 		},
 		"node_modules/@types/ws": {
@@ -307,32 +307,33 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "5.59.11",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.11.tgz",
-			"integrity": "sha512-XxuOfTkCUiOSyBWIvHlUraLw/JT/6Io1365RO6ZuI88STKMavJZPNMU0lFcUTeQXEhHiv64CbxYxBNoDVSmghg==",
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.6.0.tgz",
+			"integrity": "sha512-CW9YDGTQnNYMIo5lMeuiIG08p4E0cXrXTbcZ2saT/ETE7dWUrNxlijsQeU04qAAKkILiLzdQz+cGFxCJjaZUmA==",
 			"dev": true,
 			"dependencies": {
-				"@eslint-community/regexpp": "^4.4.0",
-				"@typescript-eslint/scope-manager": "5.59.11",
-				"@typescript-eslint/type-utils": "5.59.11",
-				"@typescript-eslint/utils": "5.59.11",
+				"@eslint-community/regexpp": "^4.5.1",
+				"@typescript-eslint/scope-manager": "6.6.0",
+				"@typescript-eslint/type-utils": "6.6.0",
+				"@typescript-eslint/utils": "6.6.0",
+				"@typescript-eslint/visitor-keys": "6.6.0",
 				"debug": "^4.3.4",
-				"grapheme-splitter": "^1.0.4",
-				"ignore": "^5.2.0",
-				"natural-compare-lite": "^1.4.0",
-				"semver": "^7.3.7",
-				"tsutils": "^3.21.0"
+				"graphemer": "^1.4.0",
+				"ignore": "^5.2.4",
+				"natural-compare": "^1.4.0",
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^5.0.0",
-				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+				"@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
+				"eslint": "^7.0.0 || ^8.0.0"
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
@@ -341,25 +342,26 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "5.59.11",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.11.tgz",
-			"integrity": "sha512-s9ZF3M+Nym6CAZEkJJeO2TFHHDsKAM3ecNkLuH4i4s8/RCPnF5JRip2GyviYkeEAcwGMJxkqG9h2dAsnA1nZpA==",
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.6.0.tgz",
+			"integrity": "sha512-setq5aJgUwtzGrhW177/i+DMLqBaJbdwGj2CPIVFFLE0NCliy5ujIdLHd2D1ysmlmsjdL2GWW+hR85neEfc12w==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "5.59.11",
-				"@typescript-eslint/types": "5.59.11",
-				"@typescript-eslint/typescript-estree": "5.59.11",
+				"@typescript-eslint/scope-manager": "6.6.0",
+				"@typescript-eslint/types": "6.6.0",
+				"@typescript-eslint/typescript-estree": "6.6.0",
+				"@typescript-eslint/visitor-keys": "6.6.0",
 				"debug": "^4.3.4"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+				"eslint": "^7.0.0 || ^8.0.0"
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
@@ -368,16 +370,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "5.59.11",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.11.tgz",
-			"integrity": "sha512-dHFOsxoLFtrIcSj5h0QoBT/89hxQONwmn3FOQ0GOQcLOOXm+MIrS8zEAhs4tWl5MraxCY3ZJpaXQQdFMc2Tu+Q==",
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.6.0.tgz",
+			"integrity": "sha512-pT08u5W/GT4KjPUmEtc2kSYvrH8x89cVzkA0Sy2aaOUIw6YxOIjA8ilwLr/1fLjOedX1QAuBpG9XggWqIIfERw==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.59.11",
-				"@typescript-eslint/visitor-keys": "5.59.11"
+				"@typescript-eslint/types": "6.6.0",
+				"@typescript-eslint/visitor-keys": "6.6.0"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -385,25 +387,25 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "5.59.11",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.59.11.tgz",
-			"integrity": "sha512-LZqVY8hMiVRF2a7/swmkStMYSoXMFlzL6sXV6U/2gL5cwnLWQgLEG8tjWPpaE4rMIdZ6VKWwcffPlo1jPfk43g==",
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.6.0.tgz",
+			"integrity": "sha512-8m16fwAcEnQc69IpeDyokNO+D5spo0w1jepWWY2Q6y5ZKNuj5EhVQXjtVAeDDqvW6Yg7dhclbsz6rTtOvcwpHg==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "5.59.11",
-				"@typescript-eslint/utils": "5.59.11",
+				"@typescript-eslint/typescript-estree": "6.6.0",
+				"@typescript-eslint/utils": "6.6.0",
 				"debug": "^4.3.4",
-				"tsutils": "^3.21.0"
+				"ts-api-utils": "^1.0.1"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "*"
+				"eslint": "^7.0.0 || ^8.0.0"
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
@@ -412,12 +414,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "5.59.11",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.11.tgz",
-			"integrity": "sha512-epoN6R6tkvBYSc+cllrz+c2sOFWkbisJZWkOE+y3xHtvYaOE6Wk6B8e114McRJwFRjGvYdJwLXQH5c9osME/AA==",
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.6.0.tgz",
+			"integrity": "sha512-CB6QpJQ6BAHlJXdwUmiaXDBmTqIE2bzGTDLADgvqtHWuhfNP3rAOK7kAgRMAET5rDRr9Utt+qAzRBdu3AhR3sg==",
 			"dev": true,
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -425,21 +427,21 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "5.59.11",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.11.tgz",
-			"integrity": "sha512-YupOpot5hJO0maupJXixi6l5ETdrITxeo5eBOeuV7RSKgYdU3G5cxO49/9WRnJq9EMrB7AuTSLH/bqOsXi7wPA==",
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.6.0.tgz",
+			"integrity": "sha512-hMcTQ6Al8MP2E6JKBAaSxSVw5bDhdmbCEhGW/V8QXkb9oNsFkA4SBuOMYVPxD3jbtQ4R/vSODBsr76R6fP3tbA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.59.11",
-				"@typescript-eslint/visitor-keys": "5.59.11",
+				"@typescript-eslint/types": "6.6.0",
+				"@typescript-eslint/visitor-keys": "6.6.0",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
-				"semver": "^7.3.7",
-				"tsutils": "^3.21.0"
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -452,42 +454,41 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "5.59.11",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.11.tgz",
-			"integrity": "sha512-didu2rHSOMUdJThLk4aZ1Or8IcO3HzCw/ZvEjTTIfjIrcdd5cvSIwwDy2AOlE7htSNp7QIZ10fLMyRCveesMLg==",
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.6.0.tgz",
+			"integrity": "sha512-mPHFoNa2bPIWWglWYdR0QfY9GN0CfvvXX1Sv6DlSTive3jlMTUy+an67//Gysc+0Me9pjitrq0LJp0nGtLgftw==",
 			"dev": true,
 			"dependencies": {
-				"@eslint-community/eslint-utils": "^4.2.0",
-				"@types/json-schema": "^7.0.9",
-				"@types/semver": "^7.3.12",
-				"@typescript-eslint/scope-manager": "5.59.11",
-				"@typescript-eslint/types": "5.59.11",
-				"@typescript-eslint/typescript-estree": "5.59.11",
-				"eslint-scope": "^5.1.1",
-				"semver": "^7.3.7"
+				"@eslint-community/eslint-utils": "^4.4.0",
+				"@types/json-schema": "^7.0.12",
+				"@types/semver": "^7.5.0",
+				"@typescript-eslint/scope-manager": "6.6.0",
+				"@typescript-eslint/types": "6.6.0",
+				"@typescript-eslint/typescript-estree": "6.6.0",
+				"semver": "^7.5.4"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+				"eslint": "^7.0.0 || ^8.0.0"
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "5.59.11",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.11.tgz",
-			"integrity": "sha512-KGYniTGG3AMTuKF9QBD7EIrvufkB6O6uX3knP73xbKLMpH+QRPcgnCxjWXSHjMRuOxFLovljqQgQpR0c7GvjoA==",
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.6.0.tgz",
+			"integrity": "sha512-L61uJT26cMOfFQ+lMZKoJNbAEckLe539VhTxiGHrWl5XSKQgA0RTBZJW2HFPy5T0ZvPVSD93QsrTKDkfNwJGyQ==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.59.11",
-				"eslint-visitor-keys": "^3.3.0"
+				"@typescript-eslint/types": "6.6.0",
+				"eslint-visitor-keys": "^3.4.1"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -918,19 +919,6 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
-		"node_modules/eslint-scope": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-			"dev": true,
-			"dependencies": {
-				"esrecurse": "^4.3.0",
-				"estraverse": "^4.1.1"
-			},
-			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
 		"node_modules/eslint-visitor-keys": {
 			"version": "3.4.3",
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
@@ -1027,15 +1015,6 @@
 				"node": ">=4.0"
 			}
 		},
-		"node_modules/estraverse": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-			"dev": true,
-			"engines": {
-				"node": ">=4.0"
-			}
-		},
 		"node_modules/esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -1051,9 +1030,9 @@
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
 		},
 		"node_modules/fast-glob": {
-			"version": "3.2.12",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-			"integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+			"integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
 			"dev": true,
 			"dependencies": {
 				"@nodelib/fs.stat": "^2.0.2",
@@ -1297,12 +1276,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/grapheme-splitter": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-			"integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
-			"dev": true
 		},
 		"node_modules/graphemer": {
 			"version": "1.4.0",
@@ -1650,12 +1623,6 @@
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true
 		},
-		"node_modules/natural-compare-lite": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
-			"integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
-			"dev": true
-		},
 		"node_modules/object-inspect": {
 			"version": "1.12.3",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
@@ -1948,9 +1915,9 @@
 			]
 		},
 		"node_modules/semver": {
-			"version": "7.5.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-			"integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
 			"dependencies": {
 				"lru-cache": "^6.0.0"
 			},
@@ -2126,6 +2093,18 @@
 				"url": "https://github.com/sponsors/Borewit"
 			}
 		},
+		"node_modules/ts-api-utils": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
+			"integrity": "sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==",
+			"dev": true,
+			"engines": {
+				"node": ">=16.13.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.2.0"
+			}
+		},
 		"node_modules/ts-mixer": {
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.3.tgz",
@@ -2135,27 +2114,6 @@
 			"version": "2.5.3",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
 			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
-		},
-		"node_modules/tsutils": {
-			"version": "3.21.0",
-			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-			"integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-			"dev": true,
-			"dependencies": {
-				"tslib": "^1.8.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			},
-			"peerDependencies": {
-				"typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
-			}
-		},
-		"node_modules/tsutils/node_modules/tslib": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-			"dev": true
 		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
@@ -2475,9 +2433,9 @@
 			"integrity": "sha512-NpaM49IGQQAUlBhHMF82QH80J08os4ZmyF9MkpCzWAGuOHqE4gTEbhzd7L3l5LmWuZ6E0OiC1FweQ4tsiW35+g=="
 		},
 		"@types/semver": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
-			"integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
+			"version": "7.5.1",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.1.tgz",
+			"integrity": "sha512-cJRQXpObxfNKkFAZbJl2yjWtJCqELQIdShsogr1d2MilP8dKD9TE/nEKHkJgUNHdGKCQaf9HbIynuV2csLGVLg==",
 			"dev": true
 		},
 		"@types/ws": {
@@ -2489,102 +2447,103 @@
 			}
 		},
 		"@typescript-eslint/eslint-plugin": {
-			"version": "5.59.11",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.11.tgz",
-			"integrity": "sha512-XxuOfTkCUiOSyBWIvHlUraLw/JT/6Io1365RO6ZuI88STKMavJZPNMU0lFcUTeQXEhHiv64CbxYxBNoDVSmghg==",
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.6.0.tgz",
+			"integrity": "sha512-CW9YDGTQnNYMIo5lMeuiIG08p4E0cXrXTbcZ2saT/ETE7dWUrNxlijsQeU04qAAKkILiLzdQz+cGFxCJjaZUmA==",
 			"dev": true,
 			"requires": {
-				"@eslint-community/regexpp": "^4.4.0",
-				"@typescript-eslint/scope-manager": "5.59.11",
-				"@typescript-eslint/type-utils": "5.59.11",
-				"@typescript-eslint/utils": "5.59.11",
+				"@eslint-community/regexpp": "^4.5.1",
+				"@typescript-eslint/scope-manager": "6.6.0",
+				"@typescript-eslint/type-utils": "6.6.0",
+				"@typescript-eslint/utils": "6.6.0",
+				"@typescript-eslint/visitor-keys": "6.6.0",
 				"debug": "^4.3.4",
-				"grapheme-splitter": "^1.0.4",
-				"ignore": "^5.2.0",
-				"natural-compare-lite": "^1.4.0",
-				"semver": "^7.3.7",
-				"tsutils": "^3.21.0"
+				"graphemer": "^1.4.0",
+				"ignore": "^5.2.4",
+				"natural-compare": "^1.4.0",
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "5.59.11",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.11.tgz",
-			"integrity": "sha512-s9ZF3M+Nym6CAZEkJJeO2TFHHDsKAM3ecNkLuH4i4s8/RCPnF5JRip2GyviYkeEAcwGMJxkqG9h2dAsnA1nZpA==",
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.6.0.tgz",
+			"integrity": "sha512-setq5aJgUwtzGrhW177/i+DMLqBaJbdwGj2CPIVFFLE0NCliy5ujIdLHd2D1ysmlmsjdL2GWW+hR85neEfc12w==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "5.59.11",
-				"@typescript-eslint/types": "5.59.11",
-				"@typescript-eslint/typescript-estree": "5.59.11",
+				"@typescript-eslint/scope-manager": "6.6.0",
+				"@typescript-eslint/types": "6.6.0",
+				"@typescript-eslint/typescript-estree": "6.6.0",
+				"@typescript-eslint/visitor-keys": "6.6.0",
 				"debug": "^4.3.4"
 			}
 		},
 		"@typescript-eslint/scope-manager": {
-			"version": "5.59.11",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.11.tgz",
-			"integrity": "sha512-dHFOsxoLFtrIcSj5h0QoBT/89hxQONwmn3FOQ0GOQcLOOXm+MIrS8zEAhs4tWl5MraxCY3ZJpaXQQdFMc2Tu+Q==",
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.6.0.tgz",
+			"integrity": "sha512-pT08u5W/GT4KjPUmEtc2kSYvrH8x89cVzkA0Sy2aaOUIw6YxOIjA8ilwLr/1fLjOedX1QAuBpG9XggWqIIfERw==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "5.59.11",
-				"@typescript-eslint/visitor-keys": "5.59.11"
+				"@typescript-eslint/types": "6.6.0",
+				"@typescript-eslint/visitor-keys": "6.6.0"
 			}
 		},
 		"@typescript-eslint/type-utils": {
-			"version": "5.59.11",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.59.11.tgz",
-			"integrity": "sha512-LZqVY8hMiVRF2a7/swmkStMYSoXMFlzL6sXV6U/2gL5cwnLWQgLEG8tjWPpaE4rMIdZ6VKWwcffPlo1jPfk43g==",
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.6.0.tgz",
+			"integrity": "sha512-8m16fwAcEnQc69IpeDyokNO+D5spo0w1jepWWY2Q6y5ZKNuj5EhVQXjtVAeDDqvW6Yg7dhclbsz6rTtOvcwpHg==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/typescript-estree": "5.59.11",
-				"@typescript-eslint/utils": "5.59.11",
+				"@typescript-eslint/typescript-estree": "6.6.0",
+				"@typescript-eslint/utils": "6.6.0",
 				"debug": "^4.3.4",
-				"tsutils": "^3.21.0"
+				"ts-api-utils": "^1.0.1"
 			}
 		},
 		"@typescript-eslint/types": {
-			"version": "5.59.11",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.11.tgz",
-			"integrity": "sha512-epoN6R6tkvBYSc+cllrz+c2sOFWkbisJZWkOE+y3xHtvYaOE6Wk6B8e114McRJwFRjGvYdJwLXQH5c9osME/AA==",
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.6.0.tgz",
+			"integrity": "sha512-CB6QpJQ6BAHlJXdwUmiaXDBmTqIE2bzGTDLADgvqtHWuhfNP3rAOK7kAgRMAET5rDRr9Utt+qAzRBdu3AhR3sg==",
 			"dev": true
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "5.59.11",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.11.tgz",
-			"integrity": "sha512-YupOpot5hJO0maupJXixi6l5ETdrITxeo5eBOeuV7RSKgYdU3G5cxO49/9WRnJq9EMrB7AuTSLH/bqOsXi7wPA==",
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.6.0.tgz",
+			"integrity": "sha512-hMcTQ6Al8MP2E6JKBAaSxSVw5bDhdmbCEhGW/V8QXkb9oNsFkA4SBuOMYVPxD3jbtQ4R/vSODBsr76R6fP3tbA==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "5.59.11",
-				"@typescript-eslint/visitor-keys": "5.59.11",
+				"@typescript-eslint/types": "6.6.0",
+				"@typescript-eslint/visitor-keys": "6.6.0",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
-				"semver": "^7.3.7",
-				"tsutils": "^3.21.0"
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
 			}
 		},
 		"@typescript-eslint/utils": {
-			"version": "5.59.11",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.11.tgz",
-			"integrity": "sha512-didu2rHSOMUdJThLk4aZ1Or8IcO3HzCw/ZvEjTTIfjIrcdd5cvSIwwDy2AOlE7htSNp7QIZ10fLMyRCveesMLg==",
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.6.0.tgz",
+			"integrity": "sha512-mPHFoNa2bPIWWglWYdR0QfY9GN0CfvvXX1Sv6DlSTive3jlMTUy+an67//Gysc+0Me9pjitrq0LJp0nGtLgftw==",
 			"dev": true,
 			"requires": {
-				"@eslint-community/eslint-utils": "^4.2.0",
-				"@types/json-schema": "^7.0.9",
-				"@types/semver": "^7.3.12",
-				"@typescript-eslint/scope-manager": "5.59.11",
-				"@typescript-eslint/types": "5.59.11",
-				"@typescript-eslint/typescript-estree": "5.59.11",
-				"eslint-scope": "^5.1.1",
-				"semver": "^7.3.7"
+				"@eslint-community/eslint-utils": "^4.4.0",
+				"@types/json-schema": "^7.0.12",
+				"@types/semver": "^7.5.0",
+				"@typescript-eslint/scope-manager": "6.6.0",
+				"@typescript-eslint/types": "6.6.0",
+				"@typescript-eslint/typescript-estree": "6.6.0",
+				"semver": "^7.5.4"
 			}
 		},
 		"@typescript-eslint/visitor-keys": {
-			"version": "5.59.11",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.11.tgz",
-			"integrity": "sha512-KGYniTGG3AMTuKF9QBD7EIrvufkB6O6uX3knP73xbKLMpH+QRPcgnCxjWXSHjMRuOxFLovljqQgQpR0c7GvjoA==",
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.6.0.tgz",
+			"integrity": "sha512-L61uJT26cMOfFQ+lMZKoJNbAEckLe539VhTxiGHrWl5XSKQgA0RTBZJW2HFPy5T0ZvPVSD93QsrTKDkfNwJGyQ==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "5.59.11",
-				"eslint-visitor-keys": "^3.3.0"
+				"@typescript-eslint/types": "6.6.0",
+				"eslint-visitor-keys": "^3.4.1"
 			}
 		},
 		"@vladfrangu/async_event_emitter": {
@@ -2927,16 +2886,6 @@
 				}
 			}
 		},
-		"eslint-scope": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-			"dev": true,
-			"requires": {
-				"esrecurse": "^4.3.0",
-				"estraverse": "^4.1.1"
-			}
-		},
 		"eslint-visitor-keys": {
 			"version": "3.4.3",
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
@@ -2988,12 +2937,6 @@
 				}
 			}
 		},
-		"estraverse": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-			"dev": true
-		},
 		"esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3006,9 +2949,9 @@
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
 		},
 		"fast-glob": {
-			"version": "3.2.12",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-			"integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+			"integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
 			"dev": true,
 			"requires": {
 				"@nodelib/fs.stat": "^2.0.2",
@@ -3197,12 +3140,6 @@
 				"merge2": "^1.4.1",
 				"slash": "^3.0.0"
 			}
-		},
-		"grapheme-splitter": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-			"integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
-			"dev": true
 		},
 		"graphemer": {
 			"version": "1.4.0",
@@ -3452,12 +3389,6 @@
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true
 		},
-		"natural-compare-lite": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
-			"integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
-			"dev": true
-		},
 		"object-inspect": {
 			"version": "1.12.3",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
@@ -3627,9 +3558,9 @@
 			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
 		},
 		"semver": {
-			"version": "7.5.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-			"integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
 			"requires": {
 				"lru-cache": "^6.0.0"
 			}
@@ -3752,6 +3683,13 @@
 				"ieee754": "^1.2.1"
 			}
 		},
+		"ts-api-utils": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
+			"integrity": "sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==",
+			"dev": true,
+			"requires": {}
+		},
 		"ts-mixer": {
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.3.tgz",
@@ -3761,23 +3699,6 @@
 			"version": "2.5.3",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
 			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
-		},
-		"tsutils": {
-			"version": "3.21.0",
-			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-			"integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-			"dev": true,
-			"requires": {
-				"tslib": "^1.8.1"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "1.14.1",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-					"dev": true
-				}
-			}
 		},
 		"type-check": {
 			"version": "0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"@typescript-eslint/eslint-plugin": "^5.59.11",
 				"@typescript-eslint/parser": "^5.59.11",
 				"eslint": "^8.43.0",
-				"typescript": "^5.1.3"
+				"typescript": "^5.2.2"
 			},
 			"engines": {
 				"node": "18"
@@ -2184,9 +2184,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-			"integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+			"integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -3799,9 +3799,9 @@
 			"dev": true
 		},
 		"typescript": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-			"integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+			"integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
 			"dev": true
 		},
 		"undici": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"node": "18"
 	},
 	"dependencies": {
-		"@colors/colors": "^1.5.0",
+		"@colors/colors": "^1.6.0",
 		"cleverbot-free": "^2.0.0",
 		"discord.js": "^14.11.0",
 		"dotenv": "^16.3.1"

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
 		"dotenv": "^16.3.1"
 	},
 	"devDependencies": {
-		"@typescript-eslint/eslint-plugin": "^5.59.11",
-		"@typescript-eslint/parser": "^5.59.11",
+		"@typescript-eslint/eslint-plugin": "^6.6.0",
+		"@typescript-eslint/parser": "^6.6.0",
 		"eslint": "^8.49.0",
 		"typescript": "^5.2.2"
 	}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
 		"@typescript-eslint/eslint-plugin": "^5.59.11",
 		"@typescript-eslint/parser": "^5.59.11",
 		"eslint": "^8.43.0",
-		"typescript": "^5.1.3"
+		"typescript": "^5.2.2"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 	"devDependencies": {
 		"@typescript-eslint/eslint-plugin": "^5.59.11",
 		"@typescript-eslint/parser": "^5.59.11",
-		"eslint": "^8.43.0",
+		"eslint": "^8.49.0",
 		"typescript": "^5.2.2"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 	"dependencies": {
 		"@colors/colors": "^1.6.0",
 		"cleverbot-free": "^2.0.0",
-		"discord.js": "^14.11.0",
+		"discord.js": "^14.13.0",
 		"dotenv": "^16.3.1"
 	},
 	"devDependencies": {

--- a/src/activity.ts
+++ b/src/activity.ts
@@ -48,7 +48,9 @@ export function start (client: Client): void {
 		error(err);
 	}
 
-	setTimeout(() => start(client), activityUpdateFrequency * 1000);
+	setTimeout(() => {
+		start(client);
+	}, activityUpdateFrequency * 1000);
 }
 
 /**

--- a/src/commands/CommandHandler.ts
+++ b/src/commands/CommandHandler.ts
@@ -46,7 +46,7 @@ export class CommandHandler extends SlashCommandBuilder {
 	public async execute (interaction: ChatInputCommandInteraction): Promise<void> {
 		if (this.execution) {
 			try {
-				return await this.execution(interaction);
+				await this.execution(interaction);
 			}
 			catch (err) {
 				error(`Command handler for /${this.name} encountered an error:`);

--- a/src/deployCommands.ts
+++ b/src/deployCommands.ts
@@ -31,7 +31,7 @@ client.once("ready", async c => {
 	await c.application.commands.set(commandJSONs);
 
 	info("Logging out...");
-	c.destroy();
+	await c.destroy();
 });
 
 // Login

--- a/src/deployCommands.ts
+++ b/src/deployCommands.ts
@@ -17,7 +17,9 @@ const token = getToken();
 info("Retrieving commands...");
 const commandHandlers = Array.from(getCommandHandlers().values());
 const commandJSONs = commandHandlers.map(command => command.toJSON());
-commandHandlers.forEach(command => debug(`\t${command.getSlashName()}`));
+commandHandlers.forEach(command => {
+	debug(`\t${command.getSlashName()}`);
+});
 
 // Setup client
 const client = new Client({ intents: [] });

--- a/src/events/EventHandler.ts
+++ b/src/events/EventHandler.ts
@@ -68,7 +68,7 @@ export class EventHandler<K extends keyof ClientEvents = keyof ClientEvents> {
 	public async execute (...args: ClientEvents[K]): Promise<void> {
 		if (this.execution) {
 			try {
-				return await this.execution(...args);
+				await this.execution(...args);
 			}
 			catch (err) {
 				error(`Event handler for "${this.name}" encountered an error:`);

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -54,7 +54,7 @@ export function debug (...params: unknown[]): void {
 }
 
 /**
- * @returns The given parameter as a string, using node's built-in `utils.inspect()` method.
+ * @returns The given parameter as a string, using node's built-in `util.inspect()` method.
  */
 function stringify (param: unknown): string {
 	if (typeof param === "string") {

--- a/src/memory/thinking.ts
+++ b/src/memory/thinking.ts
@@ -29,7 +29,9 @@ export function isThinking (channel: Channel): boolean {
  */
 export function startThinking (channel: Channel): void {
 	if (!isThinking(channel)) {
-		const timeout = setTimeout(() => stopThinking(channel), thinkingTimeout * 1000);
+		const timeout = setTimeout(() => {
+			stopThinking(channel);
+		}, thinkingTimeout * 1000);
 		thinking.set(channel.id, timeout);
 	}
 	thinking.get(channel.id)?.refresh();

--- a/src/memory/whitelist.ts
+++ b/src/memory/whitelist.ts
@@ -40,6 +40,8 @@ const whitelist: TextBasedChannel[] = [];
  * @throws If the memory file is improperly formatted
  */
 export async function load (client: Client<true>): Promise<void> {
+	whitelist.length = 0;
+
 	// Create the user's memory directory if it does not exist
 	const directoryPath = join(".", "memory", client.user.id);
 	if (!existsSync(directoryPath)) {
@@ -63,7 +65,6 @@ export async function load (client: Client<true>): Promise<void> {
 	}
 
 	// Fetch and validate channels (in parallel)
-	whitelist.length = 0;
 	await Promise.all(
 		json.map(
 			async channelID => {

--- a/src/refresh.ts
+++ b/src/refresh.ts
@@ -40,8 +40,6 @@ export async function refresh (client: Client<true>): Promise<void> {
 
 /**
  * Searchs for unread messages in whitelisted channels and responds to them.
- *
- * @param client The current logged-in client
  */
 function resumeConversations (): void {
 	getWhitelist().forEach(channel => {

--- a/src/utils/areCommandsInSync.ts
+++ b/src/utils/areCommandsInSync.ts
@@ -1,4 +1,4 @@
-import { isDeepStrictEqual } from "util";
+import { isDeepStrictEqual } from "node:util";
 
 import type { ApplicationCommand } from "discord.js";
 

--- a/src/utils/replyWithError.ts
+++ b/src/utils/replyWithError.ts
@@ -10,7 +10,7 @@ import { error } from "../logger.js";
  * @param message The message or interaction to reply to
  * @param internalError The error to send
  */
-export async function replyWithError (message: Message|ChatInputCommandInteraction, internalError: Error|unknown): Promise<void> {
+export async function replyWithError (message: Message|ChatInputCommandInteraction, internalError: unknown): Promise<void> {
 	const stringifiedError = String(internalError);
 
 	const embed = new EmbedBuilder()


### PR DESCRIPTION
## Added
- New `@typescript-eslint` stylistic rules

## Changed
- `@colors/colors` version
- `discord.js` version
- `@typescript-eslint/eslint-plugin` and `@typescript-eslint/parser` versions
- `eslint` version
- `typescript` version
- Eslint config to use consistent ESM version instead of default "latest"
- Eslint config to use new renamed configs
- Enforced new eslint rules
- Enforced new `discord.js` types
- Miscellaneous code tweaks - no functionality changes

## Fixed
- Inaccurate documentation comments