### PR TITLE
Set dependabot versioning strategy to "increase"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,4 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    versioning-strategy: "increase"


### PR DESCRIPTION
### Fixed

- Dependabot not automatically updating `package.json`