### PR TITLE
Clean up README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Exit with error code if commands are out-of-sync ([#45](https://github.com/JstnMcBrd/discord-cleverbot/pull/45))
 - Set user activity on Client initialization ([#45](https://github.com/JstnMcBrd/discord-cleverbot/pull/45))
 - Use `Object.assign` instead of `Reflect.set` ([#49](https://github.com/JstnMcBrd/discord-cleverbot/pull/49))
-- Use native Node `.env` file support instead of `dotenv` ([#51](https://github.com/JstnMcBrd/discord-cleverbot/pull/51))
-- Add Node version requirement of `>=20.6.0` ([#51](https://github.com/JstnMcBrd/discord-cleverbot/pull/51))
+- Use native Node.js `.env` file support instead of `dotenv` ([#51](https://github.com/JstnMcBrd/discord-cleverbot/pull/51))
+- Add Node.js version requirement of `>=20.6.0` ([#51](https://github.com/JstnMcBrd/discord-cleverbot/pull/51))
 - Change error subtypes to better fit their intended meaning ([#51](https://github.com/JstnMcBrd/discord-cleverbot/pull/51))
 - Classify channels using `channel.type` instead of class instances ([#52](https://github.com/JstnMcBrd/discord-cleverbot/pull/52))
 - Support `PartialGroupDMChannel` ([#64](https://github.com/JstnMcBrd/discord-cleverbot/pull/64))
-- Update runtime to Node 24 ([#67](https://github.com/JstnMcBrd/discord-cleverbot/pull/67), [#133](https://github.com/JstnMcBrd/discord-cleverbot/pull/133))
+- Update runtime to Node.js 24 ([#67](https://github.com/JstnMcBrd/discord-cleverbot/pull/67), [#133](https://github.com/JstnMcBrd/discord-cleverbot/pull/133))
 - Use `clientReady` event instead of `ready` ([#118](https://github.com/JstnMcBrd/discord-cleverbot/pull/118))
 - Use for-of loops instead of forEach method ([#143](https://github.com/JstnMcBrd/discord-cleverbot/pull/143))
 - Format error embeds as code blocks ([#153](https://github.com/JstnMcBrd/discord-cleverbot/pull/153))
@@ -46,7 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update runtime to Node 20 ([#32](https://github.com/JstnMcBrd/discord-cleverbot/pull/32))
+- Update runtime to Node.js 20 ([#32](https://github.com/JstnMcBrd/discord-cleverbot/pull/32))
 - Reformat code with new `eslint` config ([#33](https://github.com/JstnMcBrd/discord-cleverbot/pull/33), [#34](https://github.com/JstnMcBrd/discord-cleverbot/pull/34), [#36](https://github.com/JstnMcBrd/discord-cleverbot/pull/36))
 
 ### Added
@@ -103,7 +103,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use command mentions for all embeds that mention commands ([#19](https://github.com/JstnMcBrd/discord-cleverbot/pull/19))
 - Use environment variables for sensitive tokens instead of `config.json` ([#19](https://github.com/JstnMcBrd/discord-cleverbot/pull/19))
 - Bump `cleverbot-free` from v1 to v2 to improve error handling ([#19](https://github.com/JstnMcBrd/discord-cleverbot/pull/19))
-- Refactor `package.json` to follow best practices for a NodeJS project ([#19](https://github.com/JstnMcBrd/discord-cleverbot/pull/19))
+- Refactor `package.json` to follow best practices for a Node.js project ([#19](https://github.com/JstnMcBrd/discord-cleverbot/pull/19))
 - Update documentation in README for complete refactor ([#19](https://github.com/JstnMcBrd/discord-cleverbot/pull/19))
 - Improve README to be more concise ([#19](https://github.com/JstnMcBrd/discord-cleverbot/pull/19))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use for-of loops instead of forEach method ([#143](https://github.com/JstnMcBrd/discord-cleverbot/pull/143))
 - Format error embeds as code blocks ([#153](https://github.com/JstnMcBrd/discord-cleverbot/pull/153))
 - Use `Events` enum for event handler names ([#160](https://github.com/JstnMcBrd/discord-cleverbot/pull/160))
+- Clean up README ([#179](https://github.com/JstnMcBrd/discord-cleverbot/pull/179))
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## About
 
-`discord-cleverbot` is a [Discord](https://discord.com/) bot that allows users to interact with the [Cleverbot chat bot](https://www.cleverbot.com/) on Discord. It is developed in [TypeScript](https://www.typescriptlang.org/) and relies on the [Node](https://nodejs.org/) module of [cleverbot-free](https://www.npmjs.com/package/cleverbot-free).
+`discord-cleverbot` is a [Discord](https://discord.com/) bot that allows users to interact with the [Cleverbot chat bot](https://www.cleverbot.com/) on Discord. It is developed in [TypeScript](https://www.typescriptlang.org/), runs with [Node.js](https://nodejs.org/), and relies on the npm module of [cleverbot-free](https://www.npmjs.com/package/cleverbot-free).
 
 The project was started in December 2017 and has been completely rewritten several times to improve functionality, efficiency, modernity, and simplicity.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # discord-cleverbot
 
 [![API Status](https://img.shields.io/github/actions/workflow/status/IntriguingTiles/cleverbot-free/api.yml?logo=github&label=API%20Status)](https://github.com/IntriguingTiles/cleverbot-free/actions/workflows/api.yml)
-[![CI](https://img.shields.io/github/actions/workflow/status/JstnMcBrd/discord-cleverbot/ci.yml?logo=github&label=CI)](https://github.com/JstnMcBrd/discord-cleverbot/actions/workflows/ci.yml)
 
 ## About
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For legal reasons, if you choose to contribute to this project, you agree to giv
 
 ### Setting up the code
 
-- You will need an environment with [Node](https://nodejs.org/en/download) installed (or use the Dev Container - see the [Development](#development) section below).
+- You will need an environment with [Node.js](https://nodejs.org/en/download) installed.
 - Run `git clone https://github.com/JstnMcBrd/discord-cleverbot.git` to clone the repo.
 - Create a new file called `.env` and add your access token, using [`.env.example`](./.env.example) as an example.
 


### PR DESCRIPTION
- Use correct name of Node.js
- Remove outdated mention of devcontainer
- Remove CI badge (redundant - CI status is already visible)